### PR TITLE
Import button

### DIFF
--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -4,7 +4,7 @@ import { mapActions } from 'vuex';
 export default {
   name: 'DataImportExport',
   components: {},
-  inject: ['girderRest'],
+  inject: ['djangoRest'],
   data: () => ({
     importEnabled: false,
     exportEnabled: false,
@@ -30,18 +30,18 @@ export default {
       this.importErrorText = '';
       this.importErrors = false;
       try {
-        const { data: result } = await this.girderRest.post('miqa/data/import');
+        const sessions = await this.djangoRest.sessions();
+        // Just use the first session for now
+        const session = sessions[0];
+
+        await this.djangoRest.import(session.id);
         this.importing = false;
-        if (result.errorMsg) {
-          this.importErrorText = `${result.success} scans succeeded, ${result.failed} failed.\n\n${result.errorMsg}`;
-          this.importErrors = true;
-        } else {
-          this.$snackbar({
-            text: `Import finished.
-            With ${result.success} scans succeeded and ${result.failed} failed.`,
-            timeout: 6000,
-          });
-        }
+
+        this.$snackbar({
+          text: 'Import finished.',
+          timeout: 6000,
+        });
+
         this.loadSessions();
       } catch (ex) {
         this.importing = false;

--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -30,8 +30,8 @@ export default {
       this.importErrorText = '';
       this.importErrors = false;
       try {
+        // TODO: maybe call sessions() globally on app startup
         const sessions = await this.djangoRest.sessions();
-        // Just use the first session for now
         const session = sessions[0];
 
         await this.djangoRest.import(session.id);

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -29,6 +29,9 @@ const djangoClient = new Vue({
       await oauthClient.logout();
       this.user = null;
     },
+    async import(sessionId) {
+      await apiClient.post(`/sessions/${sessionId}/import`);
+    },
     async sessions() {
       const { data } = await apiClient.get('/sessions');
       const { results } = data;


### PR DESCRIPTION
Fixes #2 

I wasn't sure if this was the proper way to do it, but there doesn't appear to be a way to get the session id for the import call without calling `djangoRest.sessions()`