### PR TITLE
Idle timeout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@girder/oauth-client": "^0.7.7",
         "axios": "^0.21.1",
         "bluebird": "^3.5.5",
+        "idle-vue": "^2.0.5",
         "itk": "14.0.0",
         "lodash": "^4.17.21",
         "mousetrap": "scottwittenburg/mousetrap#fix-listener-leak",
@@ -8238,6 +8239,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/idle-js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/idle-js/-/idle-js-0.1.3.tgz",
+      "integrity": "sha512-Hvd+OLMUWfVJUv/HoX7wtBgPwx2OdcEd2TzXcBQJyuINXcf7Ig2SgxRMuq2wZNkarf/+DrzV7NxwjKcexIfWBg=="
+    },
+    "node_modules/idle-vue": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/idle-vue/-/idle-vue-2.0.5.tgz",
+      "integrity": "sha1-MA48zZWBcMTX76fMmuzoYHi+9XY=",
+      "dependencies": {
+        "idle-js": "^0.1.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -18482,7 +18500,8 @@
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-import-resolver-node": "^0.3.4",
-        "eslint-import-resolver-webpack": "^0.13.0"
+        "eslint-import-resolver-webpack": "^0.13.0",
+        "eslint-plugin-import": "^2.21.2"
       }
     },
     "@vue/eslint-config-prettier": {
@@ -23455,6 +23474,19 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      }
+    },
+    "idle-js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/idle-js/-/idle-js-0.1.3.tgz",
+      "integrity": "sha512-Hvd+OLMUWfVJUv/HoX7wtBgPwx2OdcEd2TzXcBQJyuINXcf7Ig2SgxRMuq2wZNkarf/+DrzV7NxwjKcexIfWBg=="
+    },
+    "idle-vue": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/idle-vue/-/idle-vue-2.0.5.tgz",
+      "integrity": "sha1-MA48zZWBcMTX76fMmuzoYHi+9XY=",
+      "requires": {
+        "idle-js": "^0.1.3"
       }
     },
     "ieee754": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@girder/oauth-client": "^0.7.7",
     "axios": "^0.21.1",
     "bluebird": "^3.5.5",
+    "idle-vue": "^2.0.5",
     "itk": "14.0.0",
     "lodash": "^4.17.21",
     "mousetrap": "scottwittenburg/mousetrap#fix-listener-leak",

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -90,7 +90,7 @@ export default {
         Warning
       </v-card-title>
 
-      <v-card-text class="timeout-text">
+      <v-card-text class="py-4 px-6">
         <p v-if="done">
           You have been logged out due to inactivity. Refresh the page to log
           back in
@@ -133,9 +133,3 @@ export default {
     </v-card>
   </v-dialog>
 </template>
-
-<style scoped>
-.timeout-text {
-  padding: 15px 25px !important;
-}
-</style>

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -7,33 +7,33 @@ export default {
   data: () => ({
     show: false,
     minutes: initMinutes,
-    seconds: initSeconds
+    seconds: initSeconds,
   }),
-  inject: ["djangoRest"],
+  inject: ['djangoRest'],
   computed: {
-    minutesStr(){
+    minutesStr() {
       switch (this.minutes) {
         case 0:
-          return "";
+          return '';
         case 1:
-          return "1 minute";
+          return '1 minute';
         default:
-          return this.minutes + " minutes";
+          return `${this.minutes} minutes`;
       }
     },
-    secondsStr(){
+    secondsStr() {
       switch (this.seconds) {
         case 0:
-          return "";
+          return '';
         case 1:
-          return "1 second";
+          return '1 second';
         default:
-          return this.seconds + " seconds";
+          return `${this.seconds} seconds`;
       }
     },
-    done(){
+    done() {
       return this.minutes <= 0 && this.seconds <= 0;
-    }
+    },
   },
   watch: {
     isAppIdle(idle) {
@@ -41,80 +41,101 @@ export default {
         this.show = true;
         this.decrement();
       }
-    }
+    },
   },
   methods: {
-    reset(){
+    reset() {
       this.minutes = initMinutes;
       this.seconds = initSeconds;
       this.show = false;
     },
-    logout(){
+    logout() {
       this.minutes = 0;
       this.seconds = 0;
     },
-    reload(){
+    reload() {
       this.$router.go();
     },
-    decrement(){
-      if(this.show){
-          setTimeout(() => {
-            this.seconds--;
+    decrement() {
+      if (this.show) {
+        setTimeout(() => {
+          this.seconds -= 1;
 
-            if(this.minutes <= 0 && this.seconds <= 0){
-              this.djangoRest.logout();
-              return;
-            }
+          if (this.minutes <= 0 && this.seconds <= 0) {
+            this.djangoRest.logout();
+            return;
+          }
 
-            if(this.seconds == 0){
-              this.minutes--;
-              this.seconds = initSeconds;
-            }
+          if (this.seconds === 0) {
+            this.minutes -= 1;
+            this.seconds = initSeconds;
+          }
 
-            this.decrement();
-
+          this.decrement();
         }, 1000);
       }
-
-    }
-  }
+    },
+  },
 };
 </script>
 
 <template>
-  <v-dialog v-model="this.show" width="500" persistent>
+  <v-dialog
+    v-model="show"
+    width="500"
+    persistent
+  >
     <v-card>
       <v-card-title class="text-h5 grey lighten-2">
         Warning
       </v-card-title>
 
       <v-card-text class="timeout-text">
-        <p v-if="this.done">
-          You have been logged out due to inactivity. Refresh the page to log back in
+        <p v-if="done">
+          You have been logged out due to inactivity. Refresh the page to log
+          back in
         </p>
         <p v-else>
           You have been inactive for more than 1 hour. Your session will
           automatically terminate in {{ minutesStr }} {{ secondsStr }}
         </p>
-
       </v-card-text>
 
       <v-divider />
 
       <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn v-if="!this.done" color="primary"  text @click="this.reset">Continue Session</v-btn>
-        <v-btn v-if="!this.done" color="secondary" text @click="this.logout"> Logout </v-btn>
-        <v-btn v-if="this.done" color="primary" text @click="this.reload"> Reload </v-btn>
+        <v-spacer />
+        <v-btn
+          v-if="!done"
+          color="primary"
+          text
+          @click="reset"
+        >
+          Continue Session
+        </v-btn>
+        <v-btn
+          v-if="!done"
+          color="secondary"
+          text
+          @click="logout"
+        >
+          Logout
+        </v-btn>
+        <v-btn
+          v-if="done"
+          color="primary"
+          text
+          @click="reload"
+        >
+          Reload
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
-
 <style scoped>
-.timeout-text{
+.timeout-text {
   padding: 15px 25px !important;
 }
-
 </style>

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -1,5 +1,9 @@
 <script>
-const initMinutes = 4;
+import {
+  mapState, mapActions, mapMutations,
+} from 'vuex';
+
+const initMinutes = 1;
 const initSeconds = 59;
 
 export default {
@@ -11,6 +15,7 @@ export default {
   }),
   inject: ['djangoRest'],
   computed: {
+    ...mapState(['actionTimeout']),
     minutesStr() {
       switch (this.minutes) {
         case 0:
@@ -42,12 +47,28 @@ export default {
         this.decrement();
       }
     },
+    actionTimeout(timeout) {
+      if (timeout && !this.show) {
+        this.show = true;
+        this.decrement();
+      }
+    },
+  },
+  created() {
+    this.startActionTimer();
   },
   methods: {
+    ...mapActions(['startActionTimer', 'resetActionTimer']),
+    ...mapMutations(['setActionTimeout']),
     reset() {
+      // reset dialog
+      this.show = false;
       this.minutes = initMinutes;
       this.seconds = initSeconds;
-      this.show = false;
+
+      // reset no-action timer
+      this.setActionTimeout(false);
+      this.resetActionTimer();
     },
     logout() {
       this.minutes = 0;

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -1,0 +1,46 @@
+<script>
+export default {
+  name: 'TimeoutDialog',
+  data: () => ({
+    show: false,
+  }),
+  watch: {
+    isAppIdle(idle) {
+      if (idle) {
+        this.show = true;
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <v-dialog
+    v-model="show"
+    width="500"
+  >
+    <v-card>
+      <v-card-title class="text-h5 grey lighten-2">
+        Warning
+      </v-card-title>
+
+      <v-card-text>
+        You have been inactive for more than 1 hour. Your session will
+        automatically terminate in 5 minutes
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="primary"
+          text
+          @click="show = false"
+        >
+          I accept
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/client/src/components/TimeoutDialog.vue
+++ b/client/src/components/TimeoutDialog.vue
@@ -41,6 +41,7 @@ export default {
     },
   },
   watch: {
+    // vue-idle: Adds a computed value 'isAppIdle' to all Vue objects
     isAppIdle(idle) {
       if (idle && !this.show) {
         this.show = true;

--- a/client/src/django.js
+++ b/client/src/django.js
@@ -8,9 +8,17 @@ const oauthClient = new OAuthClient(OAUTH_API_ROOT, OAUTH_CLIENT_ID);
 const djangoClient = new Vue({
   data: () => ({
     user: null,
+    store: null,
     apiClient,
   }),
   methods: {
+    setStore(store) {
+      this.store = store;
+    },
+    async resetActionTimer() {
+      await oauthClient.maybeRestoreLogin();
+      this.store.dispatch('resetActionTimer');
+    },
     async restoreLogin() {
       await oauthClient.maybeRestoreLogin();
       if (oauthClient.isLoggedIn) {
@@ -30,19 +38,23 @@ const djangoClient = new Vue({
       this.user = null;
     },
     async import(sessionId) {
+      await this.resetActionTimer();
       await apiClient.post(`/sessions/${sessionId}/import`);
     },
     async sessions() {
+      await this.resetActionTimer();
       const { data } = await apiClient.get('/sessions');
       const { results } = data;
       return results;
     },
     async sites() {
+      await this.resetActionTimer();
       const { data } = await apiClient.get('/sites');
       const { results } = data;
       return results;
     },
     async experiments(sessionId) {
+      await this.resetActionTimer();
       const { data } = await apiClient.get('/experiments', {
         params: { session: sessionId },
       });
@@ -50,6 +62,7 @@ const djangoClient = new Vue({
       return results;
     },
     async scans(experimentId) {
+      await this.resetActionTimer();
       const { data } = await apiClient.get('/scans', {
         params: { experiment: experimentId },
       });
@@ -57,22 +70,27 @@ const djangoClient = new Vue({
       return results;
     },
     async scan(scanId) {
+      await this.resetActionTimer();
       const { data } = await apiClient.get(`/scans/${scanId}`);
       return data;
     },
     async setDecision(scanId, decision) {
+      await this.resetActionTimer();
       await apiClient.post(`/scans/${scanId}/decision`, { decision });
     },
     async addScanNote(scanId, note) {
+      await this.resetActionTimer();
       await apiClient.post('/scan_notes', {
         scan: scanId,
         note,
       });
     },
     async setScanNote(scanNoteId, note) {
+      await this.resetActionTimer();
       await apiClient.put(`/scan_notes/${scanNoteId}`, { note });
     },
     async images(scanId) {
+      await this.resetActionTimer();
       const { data } = await apiClient.get('/images', {
         params: { scan: scanId },
       });

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -27,7 +27,7 @@ Vue.use(Vuetify);
 Vue.use(AsyncComputed);
 Vue.use(Girder);
 Vue.use(vMousetrap);
-Vue.use(IdleVue, { store, idleTime: 10000 });
+Vue.use(IdleVue, { store, idleTime: 3600000 }); // 1 hour inactive timeout
 
 // Merge our own (currently empty) configuration with the one provided by
 // Girder web components (needed for the login dialog to render properly)

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -51,9 +51,9 @@ if (process.env.NODE_ENV === 'production') {
   console.log = () => { };
 }
 
+djangoRest.setStore(store);
 djangoRest.restoreLogin().then(async () => {
   const user = await djangoRest.me();
-  djangoRest.setStore(store);
 
   new Vue({
     vuetify,

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -27,7 +27,7 @@ Vue.use(Vuetify);
 Vue.use(AsyncComputed);
 Vue.use(Girder);
 Vue.use(vMousetrap);
-Vue.use(IdleVue, { store, idleTime: 3600000 }); // 1 hour inactive timeout
+Vue.use(IdleVue, { store, idleTime: 900000 }); // 15 minutes inactive timeout
 
 // Merge our own (currently empty) configuration with the one provided by
 // Girder web components (needed for the login dialog to render properly)
@@ -53,6 +53,7 @@ if (process.env.NODE_ENV === 'production') {
 
 djangoRest.restoreLogin().then(async () => {
   const user = await djangoRest.me();
+  djangoRest.setStore(store);
 
   new Vue({
     vuetify,

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -4,19 +4,19 @@ import Vuetify from 'vuetify';
 import AsyncComputed from 'vue-async-computed';
 import Girder, { vuetifyConfig } from '@girder/components/src';
 import config from 'itk/itkConfig';
+import IdleVue from 'idle-vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
 import { STATIC_PATH } from './constants';
 
+import 'vuetify/dist/vuetify.min.css';
+
+import './vtk/ColorMaps';
 import vMousetrap from './vue-utilities/v-mousetrap';
 import snackbarService from './vue-utilities/snackbar-service';
 import promptService from './vue-utilities/prompt-service';
 import girder from './girder';
-
-import 'vuetify/dist/vuetify.min.css';
-
-import './vtk/ColorMaps';
 
 import djangoRest from './django';
 
@@ -27,9 +27,10 @@ Vue.use(Vuetify);
 Vue.use(AsyncComputed);
 Vue.use(Girder);
 Vue.use(vMousetrap);
+Vue.use(IdleVue, { store, idleTime: 10000 });
 
 // Merge our own (currently empty) configuration with the one provided by
-// Girder web components (needed for the login dialog to render properly).
+// Girder web components (needed for the login dialog to render properly)
 const vuetifyOptions = { ...vuetifyConfig };
 const vuetify = new Vuetify(vuetifyOptions);
 

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -30,6 +30,8 @@ let taskRunId = -1;
 let savedWorker = null;
 let sessionTimeoutId = null;
 
+const actiontime = 1800000; // 30 minute no action timeout
+
 function shrinkProxyManager(proxyManager) {
   proxyManager.getViews().forEach((view) => {
     view.setContainer(null);
@@ -182,6 +184,8 @@ const store = new Vuex.Store({
     sessionStatus: null,
     remainingSessionTime: 0,
     workerPool: new WorkerPool(poolSize, poolFunction),
+    actionTimer: null,
+    actionTimeout: false,
   },
   getters: {
     sessionStatus(state) {
@@ -332,6 +336,9 @@ const store = new Vuex.Store({
     },
     setRemainingSessionTime(state, timeRemaining) {
       state.remainingSessionTime = timeRemaining;
+    },
+    setActionTimeout(state, value) {
+      state.actionTimeout = value;
     },
   },
   actions: {
@@ -708,6 +715,15 @@ const store = new Vuex.Store({
       const sites = await djangoRest.sites();
       // let { data: sites } = await girder.rest.get("miqa_setting/site");
       state.sites = sites;
+    },
+    startActionTimer({ state, commit }) {
+      state.actionTimer = setTimeout(() => {
+        commit('setActionTimeout', true);
+      }, actiontime);
+    },
+    resetActionTimer({ state, dispatch }) {
+      clearTimeout(state.actionTimer);
+      dispatch('startActionTimer');
     },
   },
 });

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -5,17 +5,19 @@ import {
   NavigationFailureType,
   isNavigationFailure,
 } from 'vue-router/src/util/errors';
-import Layout from '@/components/Layout.vue';
+
 import {
   mapState, mapActions, mapGetters, mapMutations,
 } from 'vuex';
 
+import Layout from '@/components/Layout.vue';
 import NavbarTitle from '@/components/NavbarTitle.vue';
 import UserButton from '@/components/girder/UserButton.vue';
 import SessionsView from '@/components/SessionsView.vue';
 import WindowControl from '@/components/WindowControl.vue';
 import ScreenshotDialog from '@/components/ScreenshotDialog.vue';
 import EmailDialog from '@/components/EmailDialog.vue';
+import TimeoutDialog from '@/components/TimeoutDialog.vue';
 import KeyboardShortcutDialog from '@/components/KeyboardShortcutDialog.vue';
 import NavigationTabs from '@/components/NavigationTabs.vue';
 import SessionTimer from '@/components/SessionTimer.vue';
@@ -33,6 +35,7 @@ export default {
     WindowControl,
     ScreenshotDialog,
     EmailDialog,
+    TimeoutDialog,
     KeyboardShortcutDialog,
     NavigationTabs,
     SessionTimer,
@@ -802,6 +805,7 @@ export default {
       v-model="emailDialog"
       :notes="notes"
     />
+    <TimeoutDialog />
     <KeyboardShortcutDialog v-model="keyboardShortcutDialog" />
   </v-layout>
 </template>

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -325,7 +325,10 @@ export default {
           <v-icon>email</v-icon>
         </v-badge>
       </v-btn>
-      <UserButton @user="logoutUser()" />
+      <UserButton
+        @user="logoutUser()"
+        @login="djangoRest.login()"
+      />
     </v-app-bar>
     <v-navigation-drawer
       app


### PR DESCRIPTION
Fixes OpenImaging/miqa#3

Current approach displays timeout dialog if user has not made any actions (any one of 'mousemove', 'keydown', 'mousedown', or 'touchstart') within **1 hour**.

Timeout dialog will then log the user out (`oauthClient.logout()`) after **5 minutes** if the user does not explicitly press 'continue session'. Dialog displays dynamic timer for this

Dialog also provides action to logout directly, and refresh page after logout.

Uses [idle-vue](https://www.npmjs.com/package/idle-vue) package to detect idle status through events, but this behavior can be re-created if desired