### PR TITLE
Scan decision helpers

### DIFF
--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -215,10 +215,10 @@ export default {
       if (this.decision && this.decision !== lastDecision) {
         this.decisionChanged = true;
         await this.save();
-        console.log(this.firstDatasetInNextSession)
+
         if (this.firstDatasetInNextSession) {
           const { currentDatasetId } = this;
-          
+
           this.$router
             .push(this.firstDatasetInNextSession)
             .catch(this.handleNavigationError);
@@ -236,7 +236,6 @@ export default {
           });
         }
       }
-      
     },
     focusNote(el, e) {
       this.$refs.note.focus();
@@ -699,7 +698,7 @@ export default {
                         small
                         value="BAD"
                         color="red"
-                        :disabled="!newNote && !notes"
+                        :disabled="!newNote && notes.length === 0"
                       >
                         Bad
                       </v-btn>

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -97,7 +97,7 @@ export default {
   watch: {
     currentSession(session) {
       if (session) {
-        const last = _.last(session.decisions);
+        const last = _.head(session.decisions);
         this.decision = last ? last.decision : null;
         this.decisionChanged = false;
         this.newNote = '';
@@ -210,31 +210,33 @@ export default {
       this.newNote = e;
     },
     async onDecisionChanged() {
-      const last = _.last(this.currentSession.decisions);
+      const last = _.head(this.currentSession.decisions);
       const lastDecision = last ? last.decision : null;
       if (this.decision && this.decision !== lastDecision) {
         this.decisionChanged = true;
-        return;
-      }
-      this.decisionChanged = false;
+        await this.save();
+        console.log(this.firstDatasetInNextSession)
+        if (this.firstDatasetInNextSession) {
+          const { currentDatasetId } = this;
+          
+          this.$router
+            .push(this.firstDatasetInNextSession)
+            .catch(this.handleNavigationError);
 
-      if (this.firstDatasetInNextSession) {
-        const { currentDatasetId } = this;
-        this.$router
-          .push(this.firstDatasetInNextSession)
-          .catch(this.handleNavigationError);
-        this.$snackbar({
-          text: 'Proceeded to next session',
-          button: 'Go back',
-          timeout: 6000,
-          immediate: true,
-          callback: () => {
-            this.$router
-              .push(currentDatasetId)
-              .catch(this.handleNavigationError);
-          },
-        });
+          this.$snackbar({
+            text: 'Proceeded to next session',
+            button: 'Go back',
+            timeout: 6000,
+            immediate: true,
+            callback: () => {
+              this.$router
+                .push(currentDatasetId)
+                .catch(this.handleNavigationError);
+            },
+          });
+        }
       }
+      
     },
     focusNote(el, e) {
       this.$refs.note.focus();


### PR DESCRIPTION
Sits on top of #34 

Fixes #23, #25, #30

- Clicking on a decision immediately saves it (as well as the note if that is non-empty)
- Saving a decision advances user to next scan
- Disable 'BAD' decision without a note

Notes: Decisions received are ordered latest first, so changed `_.last` to `_.head`; maybe we should add some sorting logic on backend