### PR TITLE
allow loading files from disk

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "itk": "14.0.0",
         "lodash": "^4.17.21",
         "mousetrap": "scottwittenburg/mousetrap#fix-listener-leak",
+        "uuid": "^3.4.0",
         "vtk.js": "14.16.5",
         "vue": "^2.6.10",
         "vue-async-computed": "^3.5.1",
@@ -14727,7 +14728,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -18500,8 +18500,7 @@
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-import-resolver-node": "^0.3.4",
-        "eslint-import-resolver-webpack": "^0.13.0",
-        "eslint-plugin-import": "^2.21.2"
+        "eslint-import-resolver-webpack": "^0.13.0"
       }
     },
     "@vue/eslint-config-prettier": {
@@ -28959,8 +28958,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "itk": "14.0.0",
     "lodash": "^4.17.21",
     "mousetrap": "scottwittenburg/mousetrap#fix-listener-leak",
+    "uuid": "^3.4.0",
     "vtk.js": "14.16.5",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.5.1",

--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -12,7 +12,7 @@ export default {
     importErrors: false,
   }),
   methods: {
-    ...mapActions(['loadSession']),
+    ...mapActions(['loadSession', 'loadDataset']),
     async importData() {
       this.importing = true;
       this.importErrorText = '';
@@ -43,6 +43,12 @@ export default {
       //   positiveButton: 'Ok',
       // });
     },
+    activateInput() {
+      this.$refs.load.click();
+    },
+    loadFiles(event) {
+      this.loadDataset(event.target.files);
+    },
   },
 };
 </script>
@@ -63,6 +69,21 @@ export default {
     >
       Export
     </v-btn>
+    <v-btn
+      text
+      color="secondary"
+      @click="activateInput"
+    >
+      Load
+    </v-btn>
+
+    <input
+      ref="load"
+      type="file"
+      multiple
+      style="display: none;"
+      @change="loadFiles"
+    >
     <v-dialog
       v-model="importDialog"
       width="500"

--- a/client/src/components/DataImportExport.vue
+++ b/client/src/components/DataImportExport.vue
@@ -12,7 +12,7 @@ export default {
     importErrors: false,
   }),
   methods: {
-    ...mapActions(['loadSession', 'loadDataset']),
+    ...mapActions(['loadSession', 'loadLocalDataset']),
     async importData() {
       this.importing = true;
       this.importErrorText = '';
@@ -47,7 +47,7 @@ export default {
       this.$refs.load.click();
     },
     loadFiles(event) {
-      this.loadDataset(event.target.files);
+      this.loadLocalDataset(event.target.files);
     },
   },
 };

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -449,6 +449,7 @@ const store = new Vuex.Store({
             // nextDataset: k < images.length - 1 ? images[k + 1].id : null,
             // firstDatasetInPreviousSession: firstInPrev,
             // firstDatasetInNextSession: nextScan ? nextScan.id : null,
+            local: true,
           },
         });
 
@@ -556,7 +557,8 @@ const store = new Vuex.Store({
     // This would be called reloadSession, but session is being renamed to scan
     async reloadScan({ commit, getters }) {
       const currentImage = getters.currentDataset;
-      if (!currentImage) {
+      // No need to reload if the image doesn't exist or doesn't exist on the server
+      if (!currentImage || currentImage.local) {
         return;
       }
       const scanId = currentImage.session;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -396,7 +396,7 @@ const store = new Vuex.Store({
       await djangoRest.logout();
     },
     // load all nifti files into a single experiment + single scan
-    async loadLocalDataset({ state, commit }, files) {
+    async loadLocalDataset({ state, commit, dispatch }, files) {
       // Use a static UUID for the experiment which contains all local scans
       const experimentID = '276be8dd-aa3c-4ee7-a3a9-581783717a50';
       const scanID = uuid();
@@ -463,6 +463,8 @@ const store = new Vuex.Store({
 
       // last image
       state.datasets[prevId].nextDataset = null;
+
+      dispatch('swapToDataset', state.datasets[state.sessionDatasets[scanID][0]]);
     },
     async loadSession({ commit }, session) {
       commit('resetSession');

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -395,7 +395,7 @@ const store = new Vuex.Store({
       await djangoRest.logout();
     },
     // load all nifti files into a single experiment + single scan
-    async loadDataset({ state }, files) {
+    async loadLocalDataset({ state }, files) {
       state.experimentIds = [];
       state.experiments = {};
       state.experimentSessions = {};

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -4,6 +4,7 @@ import Vuex from 'vuex';
 import vtkProxyManager from 'vtk.js/Sources/Proxy/Core/ProxyManager';
 import { InterpolationType } from 'vtk.js/Sources/Rendering/Core/ImageProperty/Constants';
 import _ from 'lodash';
+import { v4 as uuid } from 'uuid';
 
 import '../utils/registerReaders';
 
@@ -403,9 +404,9 @@ const store = new Vuex.Store({
       state.sessionDatasets = {};
       state.datasets = {};
 
-      // TODO: replace with UUID
-      const experimentID = 1;
-      const scanID = 1;
+      // Use a static UUID for the experiment which contains all local scans
+      const experimentID = '276be8dd-aa3c-4ee7-a3a9-581783717a50';
+      const scanID = uuid();
 
       state.experimentSessions[experimentID] = [];
       state.experimentIds.push(experimentID);

--- a/client/src/views/Dataset.vue
+++ b/client/src/views/Dataset.vue
@@ -571,177 +571,179 @@ export default {
                     </v-container>
                   </v-col>
                 </v-row>
-                <v-row>
-                  <v-col
-                    class="pb-1 pt-0"
-                    cols="10"
-                  >
-                    Note history: {{ lastNoteTruncated }}
-                  </v-col>
-                  <v-col
-                    class="pb-1 pt-0"
-                    cols="1"
-                  >
-                    <v-menu
-                      ref="historyMenu"
-                      v-model="showNotePopup"
-                      :close-on-content-click="false"
-                      offset-y
-                      open-on-hover
-                      top
-                      left
+                <template v-if="!currentDataset.local">
+                  <v-row>
+                    <v-col
+                      class="pb-1 pt-0"
+                      cols="10"
                     >
-                      <template v-slot:activator="{ on }">
+                      Note history: {{ lastNoteTruncated }}
+                    </v-col>
+                    <v-col
+                      class="pb-1 pt-0"
+                      cols="1"
+                    >
+                      <v-menu
+                        ref="historyMenu"
+                        v-model="showNotePopup"
+                        :close-on-content-click="false"
+                        offset-y
+                        open-on-hover
+                        top
+                        left
+                      >
+                        <template v-slot:activator="{ on }">
+                          <v-btn
+                            v-mousetrap="{
+                              bind: 'h',
+                              handler: () => (showNotePopup = !showNotePopup)
+                            }"
+                            text
+                            small
+                            icon
+                            :disabled="notes.length < 1"
+                            class="ma-0"
+                            v-on="on"
+                          >
+                            <v-icon>arrow_drop_up</v-icon>
+                          </v-btn>
+                        </template>
+                        <v-card>
+                          <v-list-item
+                            v-for="note in notes"
+                            :key="note.id"
+                          >
+                            <v-list-item-content class="note-history">
+                              <v-list-item-title class="grey--text darken-2">
+                                {{ note.creator.first_name }}
+                                {{ note.creator.last_name }}: {{ note.created }}
+                              </v-list-item-title>
+                              {{ note.note }}
+                            </v-list-item-content>
+                          </v-list-item>
+                        </v-card>
+                      </v-menu>
+                    </v-col>
+                  </v-row>
+                  <v-row
+                    class="pb-1 pt-1"
+                  >
+                    <v-col
+                      cols="11"
+                      class="pb-1 pt-0 pr-0"
+                    >
+                      <v-text-field
+                        ref="note"
+                        v-mousetrap="{ bind: 'n', handler: focusNote }"
+                        v-mousetrap.element="{
+                          bind: 'esc',
+                          handler: () => $refs.note.blur()
+                        }"
+                        class="note-field"
+                        label="Note"
+                        solo
+                        hide-details
+                        :value="newNote"
+                        @input="setNote($event)"
+                      />
+                    </v-col>
+                    <v-col
+                      cols="1"
+                      class="pb-1 pt-0"
+                    >
+                      <v-tooltip top>
+                        <template v-slot:activator="{ on }">
+                          <v-btn
+                            text
+                            icon
+                            small
+                            color="grey"
+                            class="my-0"
+                            :disabled="!decisionChanged"
+                            v-on="on"
+                            @click="reloadScan"
+                          >
+                            <v-icon>undo</v-icon>
+                          </v-btn>
+                        </template>
+                        <span>Revert</span>
+                      </v-tooltip>
+                    </v-col>
+                  </v-row>
+                  <v-row
+                    no-gutters
+                    justify="space-between"
+                    class="pb-1"
+                  >
+                    <v-col
+                      cols="6"
+                      class="pb-1 pt-0"
+                    >
+                      <v-btn-toggle
+                        v-model="decision"
+                        class="buttons"
+                        @change="onDecisionChanged"
+                      >
                         <v-btn
                           v-mousetrap="{
-                            bind: 'h',
-                            handler: () => (showNotePopup = !showNotePopup)
+                            bind: 'b',
+                            handler: () => setDecision('BAD')
                           }"
                           text
                           small
-                          icon
-                          :disabled="notes.length < 1"
-                          class="ma-0"
-                          v-on="on"
+                          value="BAD"
+                          color="red"
+                          :disabled="!newNote && notes.length === 0"
                         >
-                          <v-icon>arrow_drop_up</v-icon>
+                          Bad
                         </v-btn>
-                      </template>
-                      <v-card>
-                        <v-list-item
-                          v-for="note in notes"
-                          :key="note.id"
-                        >
-                          <v-list-item-content class="note-history">
-                            <v-list-item-title class="grey--text darken-2">
-                              {{ note.creator.first_name }}
-                              {{ note.creator.last_name }}: {{ note.created }}
-                            </v-list-item-title>
-                            {{ note.note }}
-                          </v-list-item-content>
-                        </v-list-item>
-                      </v-card>
-                    </v-menu>
-                  </v-col>
-                </v-row>
-                <v-row
-                  class="pb-1 pt-1"
-                >
-                  <v-col
-                    cols="11"
-                    class="pb-1 pt-0 pr-0"
-                  >
-                    <v-text-field
-                      ref="note"
-                      v-mousetrap="{ bind: 'n', handler: focusNote }"
-                      v-mousetrap.element="{
-                        bind: 'esc',
-                        handler: () => $refs.note.blur()
-                      }"
-                      class="note-field"
-                      label="Note"
-                      solo
-                      hide-details
-                      :value="newNote"
-                      @input="setNote($event)"
-                    />
-                  </v-col>
-                  <v-col
-                    cols="1"
-                    class="pb-1 pt-0"
-                  >
-                    <v-tooltip top>
-                      <template v-slot:activator="{ on }">
                         <v-btn
+                          v-mousetrap="{
+                            bind: 'g',
+                            handler: () => setDecision('GOOD')
+                          }"
                           text
-                          icon
                           small
-                          color="grey"
-                          class="my-0"
-                          :disabled="!decisionChanged"
-                          v-on="on"
-                          @click="reloadScan"
+                          value="GOOD"
+                          color="green"
                         >
-                          <v-icon>undo</v-icon>
+                          Good
                         </v-btn>
-                      </template>
-                      <span>Revert</span>
-                    </v-tooltip>
-                  </v-col>
-                </v-row>
-                <v-row
-                  no-gutters
-                  justify="space-between"
-                  class="pb-1"
-                >
-                  <v-col
-                    cols="6"
-                    class="pb-1 pt-0"
-                  >
-                    <v-btn-toggle
-                      v-model="decision"
-                      class="buttons"
-                      @change="onDecisionChanged"
+                        <v-btn
+                          v-mousetrap="{
+                            bind: 'u',
+                            handler: () => setDecision('USABLE_EXTRA')
+                          }"
+                          text
+                          small
+                          value="USABLE_EXTRA"
+                          color="light-green"
+                        >
+                          Extra
+                        </v-btn>
+                      </v-btn-toggle>
+                    </v-col>
+                    <v-col
+                      cols="2"
+                      class="pb-1 pt-0"
                     >
                       <v-btn
-                        v-mousetrap="{
-                          bind: 'b',
-                          handler: () => setDecision('BAD')
-                        }"
-                        text
+                        v-mousetrap="{ bind: 'alt+s', handler: save }"
+                        color="primary"
+                        class="ma-0"
+                        style="height: 36px"
                         small
-                        value="BAD"
-                        color="red"
-                        :disabled="!newNote && notes.length === 0"
+                        :disabled="!decisionChanged && !newNote"
+                        @click="save"
                       >
-                        Bad
+                        Save
+                        <v-icon right>
+                          save
+                        </v-icon>
                       </v-btn>
-                      <v-btn
-                        v-mousetrap="{
-                          bind: 'g',
-                          handler: () => setDecision('GOOD')
-                        }"
-                        text
-                        small
-                        value="GOOD"
-                        color="green"
-                      >
-                        Good
-                      </v-btn>
-                      <v-btn
-                        v-mousetrap="{
-                          bind: 'u',
-                          handler: () => setDecision('USABLE_EXTRA')
-                        }"
-                        text
-                        small
-                        value="USABLE_EXTRA"
-                        color="light-green"
-                      >
-                        Extra
-                      </v-btn>
-                    </v-btn-toggle>
-                  </v-col>
-                  <v-col
-                    cols="2"
-                    class="pb-1 pt-0"
-                  >
-                    <v-btn
-                      v-mousetrap="{ bind: 'alt+s', handler: save }"
-                      color="primary"
-                      class="ma-0"
-                      style="height: 36px"
-                      small
-                      :disabled="!decisionChanged && !newNote"
-                      @click="save"
-                    >
-                      Save
-                      <v-icon right>
-                        save
-                      </v-icon>
-                    </v-btn>
-                  </v-col>
-                </v-row>
+                    </v-col>
+                  </v-row>
+                </template>
               </v-container>
             </v-flex>
             <v-flex


### PR DESCRIPTION
Prototype for #38 

- Add button to side panel: Prompts user to select files (only tested with nifti/*.nii.gz for now)
- Loading files creates a 'dummy' experiment + scan and adds all selected files as images belonging to scan
- Adds all selected images to fileCache to use local files instead of making server requests

Notes:
- Implementation loads a flat list of files, but modern browsers allow loading an entire directory (`webkitdirectory`), which could potentially be used to load files in the directory structure/format that import accepts